### PR TITLE
Update release date and add release notes link for 4.3

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -20,7 +20,7 @@
     <title>Commons Collections Changes</title>
   </properties>
   <body>
-  <release version="4.3" date="2018-MM-DD" description="Update from Java 7 to Java 8, bug fixes, and small changes.">
+  <release version="4.3" date="2018-12-21" description="Update from Java 7 to Java 8, bug fixes, and small changes.">
     <action issue="COLLECTIONS-691" dev="kinow" type="fix" due-to="Eitan Adler">
       Use boolean operator for boolean result.
     </action>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,6 +29,7 @@
             <item name="Security Reports"     href="/security-reports.html"/>
             <item name="Users guide"          href="/userguide.html"/>
             <item name="History"              href="/history.html"/>
+            <item name="Release Notes 4.3"    href="/release_4_3.html"/>
             <item name="Release Notes 4.2"    href="/release_4_2.html"/>
             <item name="Release Notes 4.1"    href="/release_4_1.html"/>
             <item name="Release Notes 4.0"    href="/release_4_0.html"/>


### PR DESCRIPTION
Set the release date for version 4.3 in changes.xml and add a navigation link to Release Notes 4.3 in site.xml for improved documentation and site navigation.