### PR TITLE
[COLLECTIONS-576] Fix de-serialization of MultiKey subclasses

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -22,6 +22,9 @@
   <body>
 
   <release version="4.1" date="TBD" description="">
+    <action issue="COLLECTIONS-576" dev="tn" type="fix" due-to="Stephan Roch">
+      Subclasses of MultiKey did not re-calculate their hashcode after de-serialization.
+    </action>
     <action issue="COLLECTIONS-572" dev="tn" type="add">
       Added set operations to "SetUtils": union, difference, intersection and disjunction.
       The operations return a view of the result that is backed by the input sets.

--- a/src/main/java/org/apache/commons/collections4/keyvalue/MultiKey.java
+++ b/src/main/java/org/apache/commons/collections4/keyvalue/MultiKey.java
@@ -274,7 +274,7 @@ public class MultiKey<K> implements Serializable {
      * only stable for the same process).
      * @return the instance with recalculated hash code
      */
-    private Object readResolve() {
+    protected Object readResolve() {
         calculateHashCode(keys);
         return this;
     }

--- a/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
@@ -254,4 +254,42 @@ public class MultiKeyTest extends TestCase {
         final MultiKey<?> mk2 = new MultiKey<Object>(ONE, sysKey);
         assertEquals(TWO, map2.get(mk2));
     }
+    
+    static class DerivedMultiKey<T> extends MultiKey<T> {
+
+        private static final long serialVersionUID = 1928896152249821416L;
+
+        public DerivedMultiKey(T key1, T key2) {
+            super(key1, key2);
+        }
+
+        public T getFirst() {
+            return getKey(0);
+        }
+
+        public T getSecond() {
+            return getKey(1);
+        }
+
+    }
+
+    public void testEqualsAfterSerializationOfDerivedClass() throws IOException, ClassNotFoundException
+    {
+        final DerivedMultiKey<?> mk = new DerivedMultiKey<String>("A", "B");
+
+        // serialize
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(mk);
+        out.close();
+
+        // deserialize
+        final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        final ObjectInputStream in = new ObjectInputStream(bais);
+        final DerivedMultiKey<?> mk2 = (DerivedMultiKey<?>)in.readObject();
+        in.close();
+
+        assertEquals(mk.hashCode(), mk2.hashCode());
+    }
+    
 }


### PR DESCRIPTION
[COLLECTIONS-576] Fix de-serialization of MultiKey subclasses: hashcode was not re-calculated. Thanks to Stephan Roch.  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/collections/trunk@1705620 13f79535-47bb-0310-9956-ffa450edef68